### PR TITLE
Add verzik p2 area sounds mute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.11'
+def runeLiteVersion = '1.8.24.3'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/tobqolimprovements/ToBQoLImprovementsConfig.java
+++ b/src/main/java/com/tobqolimprovements/ToBQoLImprovementsConfig.java
@@ -33,4 +33,13 @@ public interface ToBQoLImprovementsConfig extends Config
 			description = "Get rid of the pesky right-click menu when banking by just left-clicking"
 	)
 	default boolean lootChestBankAll() { return true; }
+
+	@ConfigItem(
+			keyName = "muteVerzikP2AreaSounds",
+			name = "Mute verzik P2 Area sounds",
+			description = "Change verzik back to old P2 sounds"
+	)
+	default boolean muteVerzikP2AreaSounds() {
+		return false;
+	}
 }

--- a/src/main/java/com/tobqolimprovements/ToBQoLImprovementsPlugin.java
+++ b/src/main/java/com/tobqolimprovements/ToBQoLImprovementsPlugin.java
@@ -10,10 +10,7 @@ import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
-import net.runelite.api.events.ClientTick;
-import net.runelite.api.events.GameObjectSpawned;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GameTick;
+import net.runelite.api.events.*;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
@@ -251,6 +248,17 @@ public class ToBQoLImprovementsPlugin extends Plugin
 		{
 			String option = Text.removeTags(menuEntry.getOption()).toLowerCase();
 			optionIndexes.put(option, idx++);
+		}
+	}
+
+
+	private static final int VERZIK_P2_AREA_SOUND_EFFECT_ID = 3987;
+	@Subscribe
+	public void onAreaSoundEffectPlayed(AreaSoundEffectPlayed areaSoundEffectPlayed) {
+		int soundId = areaSoundEffectPlayed.getSoundId();
+		if (config.muteVerzikP2AreaSounds() && soundId == VERZIK_P2_AREA_SOUND_EFFECT_ID)
+		{
+			areaSoundEffectPlayed.consume();
 		}
 	}
 }

--- a/src/test/java/com.tobqolimprovements/TobQolImprovementsPluginTest.java
+++ b/src/test/java/com.tobqolimprovements/TobQolImprovementsPluginTest.java
@@ -1,0 +1,13 @@
+package com.tobqolimprovements;
+
+import net.runelite.client.RuneLite;
+import net.runelite.client.externalplugins.ExternalPluginManager;
+
+public class TobQolImprovementsPluginTest
+{
+    public static void main(String[] args) throws Exception
+    {
+        ExternalPluginManager.loadBuiltin(ToBQoLImprovementsPlugin.class);
+        RuneLite.main(args);
+    }
+}


### PR DESCRIPTION
New verzik p2 attack sounds were added with this update: https://oldschool.runescape.wiki/w/Update:A_Night_At_The_Theatre_Rework. Example of the old sounds here: https://www.youtube.com/watch?v=jNbOC7BIPXs&ab_channel=GranddadJad (ignore that it's on the p2 trainer, the sounds are correct to old verzik). New sounds here: https://youtu.be/olDqj5My_LA?t=193.

I also added a test to 1-click run the dev build, copied from another plugin. Updated the runelite version because I was getting errors on launch otherwise, but not sure if you want that split out (idk if it's necessary for the code, or just to make the local client work).

I have a separate PR open with this on annoyance mute: https://github.com/Broooklyn/runelite-external-plugins/pull/78, but that's been a bit unresponsive and I think it's better grouped with other tob things anyway.